### PR TITLE
Accessibility fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,19 +16,21 @@
     <div class="wrapper">
       <div class="controls top">
         <div>
-          <label for="font-size">S</label>
+          <label aria-hidden="true">S</label>
           <input
             type="range"
+            aria-label="Font size"
             id="font-size-slider"
             name="font-size"
             min="50"
             max="330"
             />
-          <label for="font-size">L</label>
+          <label aria-hidden="true">L</label>
         </div>
       </div>
 
       <div
+        aria-label="Type here to test"
         class="container"
         id="font-input"
         spellcheck="false"

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         ><p>type here to test</p></div>
       <div class="controls bottom">
         <div>
-          <a id="download-link" download="FreeToBe.png">Download as image</a>
+          <button id="download-link" download="FreeToBe.png">Download as image</button>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -18,18 +18,22 @@
     <div class="wrapper">
       <div class="controls top">
         <div class="colorPicker">
-          <div class="colors foreground">
-            <label for="fg">FG</label>
-            <div class="fg color black selected" id="fg-black"></div>
-            <div class="fg color white" id="fg-white"></div>
-            <div class="fg color red" id="fg-red"></div>
-          </div>
-          <div class="colors background">
-            <label for="bg">BG</label>
-            <div class="bg color black" id="bg-black"></div>
-            <div class="bg color white selected" id="bg-white"></div>
-            <div class="bg color red" id="bg-red"></div>
-          </div>
+          <fieldset>
+              <div class="colors foreground">
+                <legend>FG</legend>
+                <button class="fg color black selected" aria-pressed="true" aria-label="Black foreground" id="fg-black"></button>
+                <button class="fg color white" aria-pressed="false" aria-label="White foreground" id="fg-white"></button>
+                <button class="fg color red" aria-pressed="false" aria-label="Red foreground" id="fg-red"></button>
+            </div>
+          </fieldset>
+          <fieldset>
+              <div class="colors background">
+                <legend>BG</legend>
+                <button class="bg color black" aria-pressed="false" aria-label="Black background" id="bg-black"></button>
+                <button class="bg color white selected" aria-pressed="true" aria-label="White background" id="bg-white"></button>
+                <button class="bg color red" aria-pressed="false" aria-label="Red background" id="bg-red"></button>
+            </div>
+          </fieldset>
         </div>
         <div class="slidercont">
           <label aria-hidden="true">S</label>

--- a/script.js
+++ b/script.js
@@ -134,8 +134,12 @@
     const type = e.target.classList.contains('fg') ? 'fg' : 'bg';
 
     colorPicker.querySelector(`.${type}.color.selected`)
+      .setAttribute('aria-pressed', 'false');
+    colorPicker.querySelector(`.${type}.color.selected`)
       .classList.remove('selected');
+
     e.target.classList.add('selected');
+    e.target.setAttribute('aria-pressed', 'true');
 
     const colorList = Object.keys(colors);
 
@@ -168,4 +172,3 @@
   window.onload = startup;
 
 })()
-

--- a/style.css
+++ b/style.css
@@ -89,6 +89,11 @@
         cursor: pointer;
       }
 
+      .color:focus {
+          outline: 0;
+          box-shadow: -1px 0 #888888, 0 1px #888888, 1px 0 #888888, 0 -1px #888888;
+      }
+
       .color.selected {
         box-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
       }
@@ -117,8 +122,24 @@
       }
 
 
-			.controls label {
+      .controls label, .controls legend {
         display: inline-block;
+      }
+      
+      legend {
+        padding: 0;
+        display: table;
+      }
+
+      fieldset {
+        border: 0;
+        padding: 0.01em 0 0 0;
+        margin: 0;
+        min-width: 0;
+      }
+
+      body:not(:-moz-handler-blocked) fieldset {
+        display: table-cell;
       }
 
       .slidercont {
@@ -232,7 +253,7 @@
         height: 2px;
       }
       
-      #download-link {
+      button {
           /* reset button to look like a link */
           padding: 0;
           border: none;

--- a/style.css
+++ b/style.css
@@ -90,6 +90,17 @@
       input[type=range]:focus {
         outline: none; /* Removes the blue border. You should probably do some kind of focus styling for accessibility reasons though. */
       }
+      
+            /* make the thumb grey to show when the slider has keyboard focus */
+            input[type=range]:focus::-webkit-slider-thumb {
+                background: #888888;
+            }
+            input[type=range]:focus::-moz-range-thumb {
+                background: #888888;
+            }
+            input[type=range]:focus::-ms-thumb {
+                background: #888888;
+            }
 
       input[type=range]::-ms-track {
         width: 100%;

--- a/style.css
+++ b/style.css
@@ -155,3 +155,13 @@
         background: #000;
         height: 2px;
       }
+      
+      #download-link {
+          /* reset button to look like a link */
+          padding: 0;
+          border: none;
+          font: inherit;
+          color: inherit;
+          background-color: transparent;
+          cursor: pointer;
+      }


### PR DESCRIPTION
Improves keyboard and screen reader accessibility by:
- Having a visible focus indicator on the slider
- Making the Download link a `<button>` so that it is keyboard focusable, and recognised as a button (this did not happen before because the `<a>` did not have an `href` attribute)
- Adding labels to the form fields, for screen readers and speech recognition users